### PR TITLE
Exits component redesign

### DIFF
--- a/data/morrow-base/morrow.yml
+++ b/data/morrow-base/morrow.yml
@@ -73,22 +73,18 @@
       weight: 70    # kg
       volume: 78    # lighter than human, but still take up the same space
 
-- id: morrow:exit
-  components:
-  - viewable:
-      formatter: desc_only
-      desc: You see nothing special...
-  - destination:
-
 - id: morrow:door/closed
-  base: morrow:exit
   components:
   - keywords:
     - [ door ]
-  - viewable:
-      formatter: obj
-      short: a door
-      desc: A wooden door bars your way.
+  - closable:
+      closed: true
+
+- id: morrow:door/open
+  base: morrow:door/closed
+  components:
+  - closable:
+      closed: false
 
 - id: morrow:obj/bag/small
   base: morrow:obj

--- a/data/morrow-test/test-world.yml
+++ b/data/morrow-test/test-world.yml
@@ -86,6 +86,11 @@
       short: Generic Player
       long: Player the Generic of Springdale
 
+- update: morrow:room/void
+  components:
+  - exits:
+      down: spec:room/1
+
 - id: spec:room/1
   base: morrow:room
   components:
@@ -96,10 +101,13 @@
         against hapless, helpess, and hopeless victims.  Oddly, this room is
         not yet covered in blood.
   - exits:
-      up: spec:room/1/exit/up-to-void
-      east: spec:room/1/exit/east-to-2
-      west: spec:room/1/exit/west-to-cupboard
-      north: spec:passage/hidden/open
+      up: morrow:room/void
+      east: spec:room/2
+      east_door: spec:door/1-to-2
+      west: spec:room/cupboard
+      west_door: spec:door/1-to-cupboard
+      north: spec:room/1
+      north_door: spec:door/1-to-1
   - container:
       contents:
       - spec:obj/chest_open_empty
@@ -107,25 +115,15 @@
       - spec:obj/chest_closed
       - spec:player
 
-- id: spec:passage/hidden/open
-  base: morrow:exit
+- id: spec:door/1-to-1
+  base: morrow:door/open
   components:
-  - destination: spec:room/1
-  - closable:
-      closed: false
   - keywords:
     - [ hidden, clapping ]
   - concealed
 
-- id: spec:passage/to-1
-  base: morrow:exit
-  components:
-  - destination: spec:room/1
-
-- update: morrow:room/void
-  components:
-  - exits:
-      west: spec:passage/to-1
+- id: spec:door/1-to-2
+  base: morrow:door/closed
 
 - id: spec:room/2
   base: morrow:room
@@ -136,7 +134,15 @@
         This room is oddly serene, despite the bits of gore that have been
         tracked in from the west.  Oh look, there's a ficus!
   - exits:
-      west: spec:room/2/exit/west-to-1
+      west: spec:room/1
+      west_door: spec:door/1-to-2
+
+- id: spec:door/1-to-cupboard
+  base: morrow:door/closed
+  components:
+  - keywords:
+    - [ hidden, cupboard ]
+  - concealed
 
 - id: spec:room/cupboard
   base: morrow:room
@@ -146,52 +152,8 @@
       desc: |
         Darkness, shelves, no cobwebs though.
   - exits:
-      east: spec:room/cupboard/exit/east-to-1
-
-# Used in testing for regular exits
-- id: spec:room/1/exit/up-to-void
-  base: morrow:exit
-  components:
-  - destination: morrow:room/void
-
-# Used in testing for open/close exit
-- id: spec:room/1/exit/east-to-2
-  base: morrow:exit
-  components:
-  - destination: spec:room/2
-  - keywords:
-    - [ door ]
-  - closable:
-      closed: true
-
-# Used in testing for concealed exits
-- id: spec:room/1/exit/west-to-cupboard
-  base: morrow:exit
-  components:
-  - destination: spec:room/cupboard
-  - closable:
-      closed: true
-  - keywords:
-    - [ hidden, cupboard ]
-  - concealed
-
-- id: spec:room/2/exit/west-to-1
-  base: morrow:exit
-  components:
-  - destination: spec:room/1
-  - closable:
-      closed: true
-  - keywords:
-    - [ west, door ]
-
-- id: spec:room/cupboard/exit/east-to-1
-  base: morrow:exit
-  components:
-  - destination: spec:room/1
-  - keywords:
-    - [ east, door ]
-  - closable:
-      closed: true
+      east: spec:room/1
+      east_door: spec:door/1-to-cupboard
 
 # Spawn testing
 - id: spec:obj/spawn-bag
@@ -244,45 +206,6 @@
       up:    fail
       down:  fail
 
-- id: spec:exit/open
-  base: morrow:exit
-  components:
-  - destination: morrow:room/void
-
-- id: spec:exit/door/open
-  base: morrow:exit
-  components:
-  - destination: morrow:room/void
-  - closable:
-      closed: false
-
-- id: spec:exit/door/closed
-  base: morrow:exit
-  components:
-  - destination: morrow:room/void
-  - closable:
-      closed: true
-  - keywords:
-    - [ door ]
-
-- id: spec:exit/door/open/hidden
-  base: morrow:exit
-  components:
-  - destination: morrow:room/void
-  - closable:
-      closed: false
-  - concealed
-
-- id: spec:exit/door/closed/hidden
-  base: morrow:exit
-  components:
-  - destination: morrow:room/void
-  - closable:
-      closed: true
-  - concealed
-  - keywords:
-    - [ door ]
-
 # Used for movement tests, specifically into a full room
 - id: spec:room/full
   base: morrow:room
@@ -296,7 +219,107 @@
   - exits:
       east: spec:passage/to-full
 
-- id: spec:passage/to-full
-  base: morrow:exit
+- id: spec:room/no_exits
+  base: morrow:room
+
+- id: spec:room/with_exit
+  base: morrow:room
   components:
-  - destination: spec:room/full
+  - exits:
+      east: morrow:room/void
+
+- id: spec:room/door/closed
+  base: morrow:room
+  components:
+  - exits:
+      east: morrow:room/void
+      east_door: spec:room/door/closed/target
+
+- id: spec:room/door/closed/target
+  base: morrow:door/closed
+
+- id: spec:room/door/open
+  base: morrow:room
+  components:
+  - exits:
+      east: morrow:room/void
+      east_door: spec:room/door/open/target
+
+- id: spec:room/door/open/target
+  base: morrow:door/open
+
+- id: spec:room/door/concealed/closed
+  base: morrow:room
+  components:
+  - exits:
+      east: morrow:room/void
+      east_door: spec:room/door/concealed/closed/target
+
+- id: spec:room/door/concealed/closed/target
+  base: morrow:door/closed
+  components:
+  - concealed
+
+- id: spec:room/door/concealed/open
+  base: morrow:room
+  components:
+  - exits:
+      east: morrow:room/void
+      east_door: spec:room/door/concealed/open/target
+
+- id: spec:room/door/concealed/open/target
+  base: morrow:door/open
+  components:
+  - concealed
+
+- id: spec:room/room_item/closed
+  base: morrow:room
+  components:
+  - container:
+      contents:
+      - spec:room/room_item/closed/target
+
+- id: spec:room/room_item/closed/target
+  base: morrow:obj/chest/wooden
+  components:
+  - closable:
+      closed: true
+
+- id: spec:room/room_item/open
+  base: morrow:room
+  components:
+  - container:
+      contents:
+      - spec:room/room_item/open/target
+
+- id: spec:room/room_item/open/target
+  base: morrow:obj/chest/wooden
+  components:
+  - closable:
+      closed: false
+
+- id: spec:player/inventory_item/closed
+  base: morrow:player
+  components:
+  - container:
+      contents:
+      - spec:player/inventory_item/closed/target
+
+- id: spec:player/inventory_item/closed/target
+  base: morrow:obj/bag/small
+  components:
+  - closable:
+      closed: true
+
+- id: spec:player/inventory_item/open
+  base: morrow:player
+  components:
+  - container:
+      contents:
+      - spec:player/inventory_item/open/target
+
+- id: spec:player/inventory_item/open/target
+  base: morrow:obj/bag/small
+  components:
+  - closable:
+      closed: false

--- a/lib/morrow.rb
+++ b/lib/morrow.rb
@@ -217,8 +217,8 @@ module Morrow
 end
 
 require_relative 'morrow/component'
-require_relative 'morrow/components'
 require_relative 'morrow/helpers'
+require_relative 'morrow/components'
 require_relative 'morrow/system'
 require_relative 'morrow/telnet_server'
 require_relative 'morrow/configuration'

--- a/lib/morrow/command/act_closable.rb
+++ b/lib/morrow/command/act_closable.rb
@@ -17,8 +17,7 @@ module Morrow::Command::ActClosable
       command_error 'It is already open.' if !comp.closed
 
       comp.closed = false
-      desc = entity_short(target) || "the #{entity_keywords(target)}"
-      send_to_char(char: actor, buf: 'You open %s.' % desc)
+      send_to_char(char: actor, buf: 'You open %s.' % entity_short(target))
     end
 
     # close something in the world
@@ -35,15 +34,14 @@ module Morrow::Command::ActClosable
       command_error 'It is already closed.' if comp.closed
 
       comp.closed = true
-      desc = entity_short(target) || "the #{entity_keywords(target)}"
-      send_to_char(char: actor, buf: 'You close %s.' % desc)
+      send_to_char(char: actor, buf: 'You close %s.' % entity_short(target))
     end
 
     private
 
     def closable_entities(actor)
       room = entity_location(actor)  or fault "actor has no location", actor
-      [ entity_exits(room),
+      [ entity_doors(room),
         visible_contents(actor: actor, cont: room),
         visible_contents(actor: actor, cont: actor) ]
           .flatten

--- a/lib/morrow/command/move.rb
+++ b/lib/morrow/command/move.rb
@@ -1,7 +1,7 @@
 module Morrow::Command::Move
   extend Morrow::Command
 
-  dirs = Morrow.config.components[:exits].fields.keys
+  dirs = Morrow::Helpers.exit_directions
 
   help(%w{movement} + dirs, <<~HELP)
     Syntax: #{dirs.join(", ")}
@@ -17,20 +17,18 @@ module Morrow::Command::Move
 
       exits = get_component(room, :exits) or
           command_error('Alas, you cannot go that way ...')
-      passage = exits[dir] or
+      dest = exits[dir] or
           command_error('Alas, you cannot go that way ...')
+      door = exits["#{dir}_door"]
 
-      if entity_closed?(passage)
-        if entity_concealed?(passage)
+      if door && entity_closed?(door)
+        if entity_concealed?(door)
           command_error('Alas, you cannot go that way ...')
         else
-          door = entity_short(passage) || entity_keywords(passage)
-          command_error("The #{door} is closed.")
+          command_error("#{entity_short(door).capitalize} is closed.")
         end
       else
-        dest = get_component(passage, :destination) or
-            fault("passage #{passage} has no destination")
-        error = move_entity(entity: actor, dest: dest.entity, look: true)
+        error = move_entity(entity: actor, dest: dest, look: true)
         command_error('It\'s too crowded for you to fit.') if error
       end
     end

--- a/lib/morrow/component/exits.rb
+++ b/lib/morrow/component/exits.rb
@@ -1,0 +1,11 @@
+# Maintains the list of exits from a location; one for each cardinal direction
+# used in the world.  Additionally keeps reference to any doors that bar each
+# exit.
+class Morrow::Component::Exits < Morrow::Component
+
+  Morrow::Helpers.exit_directions.each do |dir|
+    field dir, type: :entity, desc: 'room to which this exit leads'
+    field "#{dir}_door", type: :entity,
+        desc: "door barring exit to the #{dir}"
+  end
+end

--- a/lib/morrow/components.rb
+++ b/lib/morrow/components.rb
@@ -125,13 +125,6 @@ class ConcealedComponent < Component
       desc: 'If this entity has been revealed in the room'
 end
 
-class ExitsComponent < Component
-  desc 'Exits from a room; one for each cardinal direction'
-  %w{ north south east west up down }.each do |dir|
-    field dir, type: :entity, desc: "exit to the #{dir}"
-  end
-end
-
 class EnvironmentComponent < Component
   desc <<~DESC
     Environmental details for a room/container.  These things impact the
@@ -311,3 +304,5 @@ class HelpComponent < Component
   field :body
 end
 end
+
+require_relative 'component/exits.rb'

--- a/lib/morrow/configuration.rb
+++ b/lib/morrow/configuration.rb
@@ -95,7 +95,7 @@ class Morrow::Configuration
       animate: Morrow::AnimateComponent,
       corporeal: Morrow::CorporealComponent,
       concealed: Morrow::ConcealedComponent,
-      exits: Morrow::ExitsComponent,
+      exits: Morrow::Component::Exits,
       environment: Morrow::EnvironmentComponent,
       destination: Morrow::DestinationComponent,
       player_config: Morrow::PlayerConfigComponent,

--- a/lib/morrow/entity_manager.rb
+++ b/lib/morrow/entity_manager.rb
@@ -211,7 +211,7 @@ class Morrow::EntityManager
   # Get a component for an entity.
   def get_component(id, type)
     raise Morrow::UnknownEntity,
-        "unknown entity #{id}" unless entity = @entities[id]
+        "unknown entity '#{id}'" unless entity = @entities[id]
 
     index, klass = @comp_map[type]
 

--- a/lib/morrow/helpers/scriptable.rb
+++ b/lib/morrow/helpers/scriptable.rb
@@ -278,17 +278,15 @@ module Morrow::Helpers::Scriptable
     exits.get_modified_fields.values
   end
 
-  # Return the array of exits visible to actor in room.
-  def visible_exits(actor:, room:)
-
-    # XXX handle visibility checks at some point
-
+  # get all doors in this entity
+  def entity_doors(room)
     exits = get_component(room, :exits) or return []
-    exits.class.fields.map do |dir,_|
-      ex = exits.send(dir) or next
-      next if entity_closed?(ex) and entity_concealed?(ex)
-      ex
-    end.compact
+    exit_directions.inject([]) do |o, dir|
+      if exits[dir] && door = exits["#{dir}_door"]
+        o << door
+      end
+      o
+    end
   end
 
   # Returns array of Components for an entity.
@@ -389,11 +387,10 @@ module Morrow::Helpers::Scriptable
     get_component(entity, :container) != nil
   end
 
-  # entity_short
-  #
-  # Get the short description for an entity
+  # Get the short description for an entity; falls back to entity_keyword if no
+  # short was defined.
   def entity_short(entity)
-    get_component(entity, :viewable)&.short
+    get_component(entity, :viewable)&.short or "the #{entity_keywords(entity)}"
   end
 
   # entity_desc
@@ -415,5 +412,10 @@ module Morrow::Helpers::Scriptable
   # Get the weight for an entity
   def entity_weight(entity)
     get_component(entity, :corporeal)&.weight || 0
+  end
+
+  # Get the list of possible exit directions from any room.
+  def exit_directions
+    @exit_directions ||= %w{ north south east west up down }
   end
 end

--- a/spec/lib/morrow/command/act_closable_spec.rb
+++ b/spec/lib/morrow/command/act_closable_spec.rb
@@ -11,138 +11,82 @@ describe Morrow::Command::ActClosable do
     player_output(leo).clear
   end
 
-  describe 'open' do
-    describe 'exit' do
-      context 'that is closed' do
-        before(:each) { run_cmd(leo, 'open hidden-cupboard') }
+  [ { desc: 'open a closed door',
+      room: 'spec:room/door/closed',
+      cmd: 'open door',
+      closed: false,
+      output: 'You open the door.' },
+    { desc: 'open an open door',
+      room: 'spec:room/door/open',
+      cmd: 'open door',
+      closed: false,
+      output: 'It is already open.' },
+    { desc: 'open closed object in the room',
+      room: 'spec:room/room_item/closed',
+      cmd: 'open chest',
+      closed: false,
+      output: 'You open a wooden chest.' },
+    { desc: 'open an open object in the room',
+      room: 'spec:room/room_item/open',
+      cmd: 'open chest',
+      closed: false,
+      output: 'It is already open.' },
+    { desc: 'open a closed inventory item',
+      actor: 'spec:player/inventory_item/closed',
+      cmd: 'open bag',
+      closed: false,
+      output: 'You open a small bag.' },
+    { desc: 'open an open inventory item',
+      actor: 'spec:player/inventory_item/open',
+      cmd: 'open bag',
+      closed: false,
+      output: 'It is already open.' },
 
-        it 'will open the exit' do
-          expect(entity_closed?('spec:room/1/exit/west-to-cupboard'))
-              .to be(false)
-        end
+    { desc: 'close a closed door',
+      room: 'spec:room/door/closed',
+      cmd: 'close door',
+      closed: true,
+      output: 'It is already closed.' },
+    { desc: 'close an open door',
+      room: 'spec:room/door/open',
+      cmd: 'close door',
+      closed: true,
+      output: 'You close the door.' },
+    { desc: 'close closed object in the room',
+      room: 'spec:room/room_item/closed',
+      cmd: 'close chest',
+      closed: true,
+      output: 'It is already closed.' },
+    { desc: 'close an open object in the room',
+      room: 'spec:room/room_item/open',
+      cmd: 'close chest',
+      closed: true,
+      output: 'You close a wooden chest.' },
+    { desc: 'close a closed inventory item',
+      actor: 'spec:player/inventory_item/closed',
+      cmd: 'close bag',
+      closed: true,
+      output: 'It is already closed.' },
+    { desc: 'close an open inventory item',
+      actor: 'spec:player/inventory_item/open',
+      cmd: 'close bag',
+      closed: true,
+      output: 'You close a small bag.' },
+    ].each do |p|
+      describe "#{p[:desc]}" do
+        let(:room) { p[:room] } if p[:room]
+        let(:leo) { p[:actor] } if p[:actor]
+        let(:target) { "#{p[:room] || p[:actor]}/target" }
 
-        it 'will output "You open the hidden-cupboard."' do
-          expect(output).to include("You open the hidden-cupboard.")
-        end
-      end
-      context 'that is open' do
-        it 'will output "It is already open."' do
-          get_component('spec:room/1/exit/west-to-cupboard', :closable)
-              .closed = false
-          run_cmd(leo, 'open hidden-cupboard')
-          expect(output).to include('It is already open.')
-        end
-      end
-    end
-    describe 'obj in room' do
-      context 'that is closed' do
-        before(:each) { run_cmd(leo, 'open chest-closed') }
+        before(:each) { run_cmd(leo, p[:cmd]) }
 
-        it 'will open the chest' do
-          expect(entity_closed?('spec:obj/chest_closed'))
-              .to be(false)
-        end
-
-        it 'will output "You open a wooden chest."' do
-          expect(output).to include("You open a wooden chest.")
-        end
-      end
-      context 'that is open' do
-        it 'will output "It is already open."' do
-          run_cmd(leo, 'open chest-open')
-          expect(output).to include('It is already open.')
-        end
-      end
-    end
-
-    describe 'carried obj' do
-      context 'that is closed' do
-        before(:each) { run_cmd(leo, 'open leo-bag-closed') }
-
-        it 'will open the bag' do
-          expect(entity_closed?('spec:mob/leo/bag_closed'))
-              .to be(false)
-        end
-
-        it 'will output "You open a small bag."' do
-          expect(output).to include("You open a small bag.")
-        end
-      end
-      context 'that is open' do
-        it 'will output "It is already open."' do
-          run_cmd(leo, 'open leo-bag-open')
-          expect(output).to include('It is already open.')
-        end
-      end
-    end
-  end
-
-  describe 'close' do
-    describe 'exit' do
-      context 'that is open' do
-        before(:each) do
-          get_component('spec:room/1/exit/west-to-cupboard', :closable)
-              .closed = false
-          run_cmd(leo, 'close hidden-cupboard')
+        it 'the target will be %s' % [ p[:closed] ? 'closed' : 'open' ] do
+          expect(entity_closed?(target)).to be(p[:closed])
         end
 
-        it 'will closed the exit' do
-          expect(entity_closed?('spec:room/1/exit/west-to-cupboard'))
-              .to be(true)
-        end
-
-        it 'will output "You close the hidden-cupboard."' do
-          expect(output).to include("You close the hidden-cupboard.")
-        end
-      end
-
-      context 'that is closed' do
-        it 'will output "It is already closed."' do
-          run_cmd(leo, 'close hidden-cupboard')
-          expect(output).to include('It is already closed.')
+        it "will output '#{p[:output]}'" do
+          expect(output).to include(p[:output])
         end
       end
     end
-
-    describe 'obj in room' do
-      context 'that is open' do
-        before(:each) { run_cmd(leo, 'close chest-open-empty') }
-
-        it 'will closed the chest' do
-          expect(entity_closed?('spec:obj/chest_open_empty')) .to be(true)
-        end
-
-        it 'will output "You close an wooden chest."' do
-          expect(output).to include("You close an open wooden chest.")
-        end
-      end
-      context 'that is closed' do
-        it 'will output "It is already closed."' do
-          run_cmd(leo, 'close chest-closed')
-          expect(output).to include('It is already closed.')
-        end
-      end
-    end
-
-    describe 'carried obj' do
-      context 'that is open' do
-        before(:each) { run_cmd(leo, 'close leo-bag-open') }
-
-        it 'will closed the bag' do
-          expect(entity_closed?('spec:mob/leo/bag_open'))
-              .to be(true)
-        end
-
-        it 'will output "You closed a small bag."' do
-          expect(output).to include("You close a small bag.")
-        end
-      end
-      context 'that is closed' do
-        it 'will output "It is already closed."' do
-          run_cmd(leo, 'close leo-bag-closed')
-          expect(output).to include('It is already closed.')
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
Previously Exits contained references to "passage" entities that had
a destination, and optionally a closable component.  This caused a
couple of issues:

* To connect two room entities, you needed two passage entities to
  create a bi-directional link (which is most common)
    * This causes the number of entities in the system to balloon
      when we pull in a map of ~10k rooms (ended up with 30k
      entities)
* When you opened a door in one room, the door on the other side
  would still be closed because the closed state resided in each
  independent passage entity

So to fix both of these issues, I tossed out the idea of a passage.

For each direction from a room, the Exits component has a destination
in that direction (entity id), and optionally a door entity that
maintains the closable component for both sides of the door.

```yml
- id: example:room/1
  base: morrow:room
  components:
  - exits:
      east: example:room/2
      east_door: example:door/1-to-2

- id: example:room/2
  base: morrow:room
  components:
  - exits:
     west: example:room/1
     west_door: example:door/1-to-2

- id: example:door/1-to-2
  base: morrow:door/closed
```

fixes #12 